### PR TITLE
Changed global output to make it compatible in NPM

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -35,6 +35,7 @@ function getWebpackConfig(env: string) {
 			library: 'Digizuite',
 			libraryTarget: 'umd',
 			umdNamedDefine: true,
+			globalObject: 'this'
 		},
 		mode: env === ENV_PRODUCTION ? 'production' : 'development',
 		externals: {


### PR DESCRIPTION
Changed global output from `window` to `this` in order to make it NPM lovable.